### PR TITLE
tests: create basic API tests with no mocking yet

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,0 @@
-const app = require('express')()
-
-app.get('/', (req, res) => res.send('Hello world!'))
-
-app.listen(process.env.APP_PORT || 3000, () => console.log('Listening'))

--- a/docs/apiary.apib
+++ b/docs/apiary.apib
@@ -113,7 +113,8 @@ Resources related to handling with Boards.
                     "number": 39432,
                     "subject": "A subject for a Thread",
                     "body": "The text of the Thread",
-                    "url": "/boards/comp/threads/39432"
+                    "url": "/boards/comp/threads/39432",
+                    "replies": []
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "supertest": "^3.0.0"
   },
   "scripts": {
-    "test": "yarn run jest",
+    "test": "npm run jest",
     "start": "node src/server.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "dependencies": {
     "body-parser": "1.18.2",
     "express": "4.16.2",
-    "jest": "22.0.5",
     "sequelize": "4.30.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^22.0.5",
+    "supertest": "^3.0.0"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node app.js"
+    "test": "yarn run jest",
+    "start": "node src/server.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "supertest": "^3.0.0"
   },
   "scripts": {
-    "test": "npm run jest",
+    "test": "jest",
     "start": "node src/server.js"
   },
   "repository": {

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,5 @@
+const app = require('express')()
+
+app.get('/', (req, res) => res.status(404).send('Not found'))
+
+module.exports = app

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,6 @@
+const app = require('./app')
+const port = process.env.APP_PORT || 3000
+
+app.listen(port, () => {
+    console.log('Listening on port ' + port);
+})

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,170 @@
+const request = require('supertest')
+const app = require('../src/app')
+
+describe('Test the root path', () => {
+    test('GET / should respond with a 404', () => {
+        return request(app).get('/').expect(404)
+    })
+})
+
+describe('Test the /boards path', () => {
+  test('GET /boards should respond with all boards', () => {
+    return request(app).get('/boards')
+      .expect('Content-Type', /json/)
+      .expect(200)
+  })
+
+  test('POST /boards should create a new board', () => {
+    return request(app).post('/boards')
+      .field('slug', 'comp')
+      .field('name', 'Computarias')
+      .expect('Content-Type', /json/)
+      .expect(201, {
+        board: {
+          slug: 'comp',
+          name: 'Computarias',
+          url: '/boards/comp'
+        }
+      })
+  })
+
+  test('POST /boards should not create without slug', () => {
+    return request(app).post('/boards')
+      .field('name', 'Computarias')
+      .expect('Content-Type', /json/)
+      .expect(422, {
+        error: 'Missing board slug'
+      })
+  })
+
+  test('POST /boards should not create without name', () => {
+    return request(app).post('/boards')
+      .field('slug', 'comp')
+      .expect('Content-Type', /json/)
+      .expect(422, {
+        error: 'Missing board name'
+      })
+  })
+
+  test('GET /boards/{slug} should 404 for inexistent board', () => {
+    return request(app).get('/boards/kek')
+      .expect(404)
+  })
+
+  test('GET /boards/{slug} should respond with a valid board', () => {
+    return request(app).get('/boards/comp')
+      .expect('Content-Type', /json/)
+      .expect(200, {
+        board: {
+          slug: 'comp',
+          name: 'Computarias',
+          url: '/boards/comp'
+        }
+      })
+  })
+})
+
+describe('Test the /boards path', () => {
+  test('GET /boards/{slug}/threads should respond with all threads', () => {
+    return request(app).get('/boards/comp/threads')
+      .expect('Content-Type', /json/)
+      .expect(200, {
+        board: {
+          slug: 'comp',
+          name: 'Computarias',
+          url: '/boards/comp',
+          threads: []
+        }
+      })
+  })
+
+  test('GET /boards/{slug}/threads should 404 for an invalid slug', () => {
+    return request(app).get('/boards/kek/threads')
+      .expect(404)
+  })
+
+  test ('POST /boards/{slug}/threads should create a new thread', () => {
+    return request(app).post('/boards/comp/threads')
+      .field('subject', 'Random Subject')
+      .field('body', 'A random text for a new thread.')
+      .expect('Content-Type', /json/)
+      .expect(201, {
+        thread: {
+          number: 1,
+          subject: 'Random Subject',
+          body: 'A random text for a new thread.'
+        }
+      })
+  })
+
+  test('POST /boards/{slug}/threads should create a new thread without a subject', () => {
+    return request(app).post('/boards/comp/threads')
+      .field('body', 'A random text for a new thread.')
+      .expect('Content-Type', /json/)
+      .expect(201, {
+        thread: {
+          number: 2,
+          subject: '',
+          body: 'A random text for a new thread.',
+          replies: []
+        }
+      })
+  })
+
+  test('POST /boards/{slug}/threads should not create a new thread without a body', () => {
+    return request(app).post('/boards/comp/threads')
+      .expect(422, {
+        error: 'Missing post body'
+      })
+  })
+
+  test('GET /boards/{slug}/threads/{number} should 404 if inexistent thread', () => {
+    return request(app).get('/boards/comp/threads/4945930')
+      .expect(404)
+  })
+
+  test('GET /boards/{slug}/threads/{number} should 404 if invalid number', () => {
+    return request(app).get('/boards/comp/threads/kek')
+      .expect(404)
+  })
+
+  test('GET /boards/{slug}/threads/{number} should return thread', () => {
+    return request(app).get('/boards/comp/threads/1')
+      .expect('Content-Type', /json/)
+      .expect(200, {
+        thread: {
+          number: 1,
+          subject: 'Random Subject',
+          body: 'A random text for a new thread.',
+          replies: []
+        }
+      })
+  })
+
+  test('POST /boards/{slug}/threads/{number} should create a new reply', () => {
+    return request(app).post('/boards/comp/threads/1')
+      .field('body', 'A random reply.')
+      .expect('Content-Type', /json/)
+      .expect(201, {
+        thread: {
+          number: 1,
+          subject: 'Random Subject',
+          body: 'A random text for a new thread.',
+          replies: [
+            {
+              number: 3,
+              body: 'A random reply.'
+            }
+          ]
+        }
+      })
+  })
+
+  test('POST /boards/{slug}/threads/{number} should not create a new reply without a body', () => {
+    return request(app).post('/boards/comp/threads/1')
+      .field('body', 'A random reply.')
+      .expect(422, {
+        error: 'Missing post body'
+      })
+  })
+})


### PR DESCRIPTION
Separates the server logic into `src/server.js` so that `src/app.js` can be imported into the tests.

There's no mocking yet, so most tests will always fail.